### PR TITLE
use `cv2.cv` if importing `cv` fails

### DIFF
--- a/opencv_engine/engine.py
+++ b/opencv_engine/engine.py
@@ -8,7 +8,11 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2014 globo.com timehome@corp.globo.com
 
-import cv
+try:
+    import cv
+except ImportError:
+    import cv2.cv as cv
+
 from colour import Color
 
 from thumbor.engines import BaseEngine


### PR DESCRIPTION
... as in https://github.com/thumbor/thumbor/blob/master/thumbor/detectors/local_detector.py
