### PR TITLE
Exif applies only for JPEG format

### DIFF
--- a/opencv_engine/engine.py
+++ b/opencv_engine/engine.py
@@ -65,10 +65,13 @@ class Engine(BaseEngine):
         img0 = cv.DecodeImageM(imagefiledata, cv.CV_LOAD_IMAGE_UNCHANGED)
 
         if FORMATS[self.extension] == 'JPEG':
-            info = JpegFile.fromString(buffer).get_exif()
-            if info:
-                self.exif = info.data
-                self.exif_marker = info.marker
+            try:
+                info = JpegFile.fromString(buffer).get_exif()
+                if info:
+                    self.exif = info.data
+                    self.exif_marker = info.marker
+            except Exception:
+                pass
 
         return img0
 


### PR DESCRIPTION
If we preserve Exif info and we ask for PNG output with filter format(png), thumbor crash:

 2014-11-27 15:50:21 thumbor:ERROR ERROR: Traceback (most recent call last):
   File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 1320, in _stack_context_handle_exception
     raise_exc_info((type, value, traceback))
   File "/usr/local/lib/python2.7/dist-packages/tornado/stack_context.py", line 302, in wrapped
     ret = fn(_args, *_kwargs)
   File "/usr/local/lib/python2.7/dist-packages/thumbor/loaders/http_loader.py", line 49, in return_contents
     callback(response.body)
   File "/usr/local/lib/python2.7/dist-packages/thumbor/handlers/__init__.py", line 333, in handle_loader_loaded
     callback(normalized, engine=self.context.request.engine)
   File "/usr/local/lib/python2.7/dist-packages/thumbor/handlers/**init**.py", line 99, in callback
     self.filters_runner.apply_filters(thumbor.filters.PHASE_AFTER_LOAD, transform)
   File "/usr/local/lib/python2.7/dist-packages/thumbor/filters/**init**.py", line 81, in apply_filters
     callback()
   File "/usr/local/lib/python2.7/dist-packages/thumbor/handlers/**init**.py", line 97, in transform
     Transformer(self.context).transform(after_transform_cb)
   File "/usr/local/lib/python2.7/dist-packages/thumbor/transformer.py", line 88, in transform
     self.smart_detect()
   File "/usr/local/lib/python2.7/dist-packages/thumbor/transformer.py", line 156, in smart_detect
     self.do_image_operations()
   File "/usr/local/lib/python2.7/dist-packages/thumbor/transformer.py", line 199, in do_image_operations
     self.done_callback()
   File "/usr/local/lib/python2.7/dist-packages/thumbor/handlers/**init**.py", line 141, in after_transform
     self.filters_runner.apply_filters(thumbor.filters.PHASE_POST_TRANSFORM, finish_callback)
   File "/usr/local/lib/python2.7/dist-packages/thumbor/filters/**init**.py", line 91, in apply_filters
     exec_one_filter()
   File "/usr/local/lib/python2.7/dist-packages/thumbor/filters/**init**.py", line 90, in exec_one_filter
     f.run(exec_one_filter)
   File "/usr/local/lib/python2.7/dist-packages/thumbor/filters/**init**.py", line 201, in run
     callback()
   File "/usr/local/lib/python2.7/dist-packages/thumbor/filters/**init**.py", line 86, in exec_one_filter
     callback()
   File "/usr/local/lib/python2.7/dist-packages/thumbor/handlers/**init**.py", line 196, in finish_request
     results = context.request.engine.read(image_extension, quality)
   File "/usr/local/lib/python2.7/dist-packages/opencv_engine/engine.py", line 145, in read
     img = JpegFile.fromString(data)
   File "/usr/local/lib/python2.7/dist-packages/pexif.py", line 981, in fromString
     return JpegFile(StringIO.StringIO(str), "from buffer", mode=mode)
   File "/usr/local/lib/python2.7/dist-packages/pexif.py", line 1015, in **init**
     "should be <%s>" % (soi_marker, SOI_MARKER))
 InvalidFile: Error reading soi_marker. Got <?P> should be <??>
